### PR TITLE
Added a regex based filter

### DIFF
--- a/src/main/java/com/hazelcast/diagnostics/LatencyDistributionPane.java
+++ b/src/main/java/com/hazelcast/diagnostics/LatencyDistributionPane.java
@@ -87,7 +87,6 @@ public class LatencyDistributionPane {
                     continue;
                 }
 
-                System.out.println(distribution);
                 for (Map.Entry<Long, Long> e : distribution.entrySet()) {
                     dataset.addValue(e.getValue(), diagnostics.getDirectory().getName(),e.getKey());
                 }


### PR DESCRIPTION
When there are a large number of different metrics, it is extremely difficult to find the right metric in the combobox. The regex based filter helps to solve that problem. If you want e.g. only the metrics for outbound queue size, just add

`.*writeQueueSize.*`